### PR TITLE
fixed 2d by checking if box size is exactly 1.0f or not

### DIFF
--- a/src/coordinate.cpp
+++ b/src/coordinate.cpp
@@ -175,6 +175,14 @@ Coordinate Coordinate::closest_image(const Coordinate& other, const Coordinate& 
   return imageflag;
 }
 
+float Coordinate::min2D()const
+{
+	float minimum = x;
+	if(y<minimum) minimum = y;
+
+	return minimum;
+}
+
 float Coordinate::min()const
 {
 	float minimum = x;

--- a/src/coordinate.h
+++ b/src/coordinate.h
@@ -59,6 +59,7 @@ class Coordinate
     float length_unwrapped(const Coordinate&)const;	//returns length of shortest vector, allowing box wrapping
     Coordinate vector_unwrapped(const Coordinate&)const;	//returns shortest vector, allowing box wrapping
     Coordinate closest_image(const Coordinate&, const Coordinate&)const;	//returns index (integer) coordinate providing image correction that must be applied to get the shortest distance
+    float min2D()const;			//returns minimum of two coordinate values
     float min()const;			//returns minimum of three coordinate values
     float max()const;			//returns maximum of three coordinate values
     

--- a/src/radial_count.cpp
+++ b/src/radial_count.cpp
@@ -35,7 +35,12 @@ Radial_Count::Radial_Count(System*sys, int nbins, int timescheme, float maxdista
   system=sys;
   n_bins=nbins;
   minboxsize=(system->min_box_dimensions()).min();
-  
+
+  if(std::fabs(minboxsize - 1.0f) <= 1e-7f)
+  {
+    minboxsize=(system->min_box_dimensions()).min2D();
+  }
+
   if(maxdistance>0&&maxdistance<minboxsize/2)
   {
     max_distance=maxdistance;
@@ -43,7 +48,7 @@ Radial_Count::Radial_Count(System*sys, int nbins, int timescheme, float maxdista
   else
   {
     max_distance = minboxsize/2;
-    cout << "\nMax length scale binned selected by user for rdf is not between 0 and half the smallest box dimension. Defaulting to half smallest box dimension.\n";
+    cout << "\nMax length scale binned selected by user for rdf is not between 0 and half the smallest box dimension. Defaulting to half smallest box dimension. Max_distance: " << max_distance << "\n";
   }
   
   time_scheme = timescheme;
@@ -168,6 +173,11 @@ void Radial_Count::set(System*sys, int nbins, int timescheme, float maxdistance)
   n_bins=nbins;
   minboxsize=(system->min_box_dimensions()).min();
   
+  if(std::fabs(minboxsize - 1.0f) <= 1e-7f)
+  {
+    minboxsize=(system->min_box_dimensions()).min2D();
+  }
+
   if(maxdistance>0&&maxdistance<minboxsize/2)
   {
     max_distance=maxdistance;

--- a/src/radial_distribution_function.cpp
+++ b/src/radial_distribution_function.cpp
@@ -35,7 +35,12 @@ Radial_Distribution_Function::Radial_Distribution_Function(System*sys, int nbins
   system=sys;
   n_bins=nbins;
   minboxsize=(system->min_box_dimensions()).min();
-  
+
+  if(std::fabs(minboxsize - 1.0f) <= 1e-7f)
+  {
+    minboxsize=(system->min_box_dimensions()).min2D();
+  }
+
   if(maxdistance>0&&maxdistance<minboxsize/2)
   {
     max_distance=maxdistance;
@@ -43,7 +48,7 @@ Radial_Distribution_Function::Radial_Distribution_Function(System*sys, int nbins
   else
   {
     max_distance = minboxsize/2;
-    cout << "\nMax length scale binned selected by user for rdf is not between 0 and half the smallest box dimension. Defaulting to half smallest box dimension.\n";
+    cout << "\nMax length scale binned selected by user for rdf is not between 0 and half the smallest box dimension. Defaulting to half smallest box dimension. Max_distance: " << max_distance << "\n";
   }
   
   time_scheme = timescheme;
@@ -168,6 +173,11 @@ void Radial_Distribution_Function::set(System*sys, int nbins, int timescheme, fl
   n_bins=nbins;
   minboxsize=(system->min_box_dimensions()).min();
   
+  if(std::fabs(minboxsize - 1.0f) <= 1e-7f)
+  {
+    minboxsize=(system->min_box_dimensions()).min2D();
+  }
+
   if(maxdistance>0&&maxdistance<minboxsize/2)
   {
     max_distance=maxdistance;


### PR DESCRIPTION
Added a simple fix to RDF (and radial_count) classes that query the minimum box size in constructor/set commands.

Basically checks if the minimum box size is equal to 1.0f. If so, checks minimum box size in x and y dimensions only.

@dssimmons is this a good way to fix this? Also, wave_factor classes use a bunch of these commands and I didn't check if they need fixing. Should I? Other than that class, this fixes all instances of such commands as far as I can tell.