### PR TITLE
Update command syntax for msd to msd_2d

### DIFF
--- a/Manual/msd_2d.md
+++ b/Manual/msd_2d.md
@@ -11,7 +11,7 @@ where S is the number of start times employed, N is the number of particles, $\b
 <h2>Syntax</h2>
 
 ```
-msd <output file> <plane:"xy","yz","xz">
+msd_2d <output file> <plane:"xy","yz","xz">
 <target>
 ```
 


### PR DESCRIPTION
Fixed manual command syntax for `msd_2d`, was previously `msd`